### PR TITLE
feat: 미션 피드백 알림 클릭 시 해당 페이지로 이동 기능 추가

### DIFF
--- a/src/components/common/SideModal/Notification.jsx
+++ b/src/components/common/SideModal/Notification.jsx
@@ -113,6 +113,11 @@ function Notification({ onClose, onOpenModal, isOpen, notifications, setNotifica
             return
         }
 
+        if(noti.type === "MISSION_FEEDBACK") {
+            navigate(`/mission/${noti.targetId}`);
+            onClose();
+            return;
+        }
         // TODO: 나중에 다른 타입 분기 추가
     }
     
@@ -182,7 +187,7 @@ function formatTimeAgo(dateStr) {
 }
 
 function mapTypeToCategory(type) {
-    if (["PRAISE_RECEIVED", "DIARY_COMMENT", "DIARY_LIKE"].includes(type)) return "ACTIVITY";
+    if (["PRAISE_RECEIVED", "DIARY_COMMENT", "DIARY_LIKE", "MiSSION_FEEDBACK"].includes(type)) return "ACTIVITY";
     if (["LEVEL_UP", "MISSION_REWARD"].includes(type)) return "REWARD";
     return "ACTIVITY";
 }

--- a/src/components/common/SideModal/Notification.jsx
+++ b/src/components/common/SideModal/Notification.jsx
@@ -187,7 +187,7 @@ function formatTimeAgo(dateStr) {
 }
 
 function mapTypeToCategory(type) {
-    if (["PRAISE_RECEIVED", "DIARY_COMMENT", "DIARY_LIKE", "MiSSION_FEEDBACK"].includes(type)) return "ACTIVITY";
+    if (["PRAISE_RECEIVED", "DIARY_COMMENT", "DIARY_LIKE", "MISSION_FEEDBACK"].includes(type)) return "ACTIVITY";
     if (["LEVEL_UP", "MISSION_REWARD"].includes(type)) return "REWARD";
     return "ACTIVITY";
 }


### PR DESCRIPTION
close#5 

- 강사에게 피드백을 받을 경우 알림을 받게 됩니다
- 해당 알림을 클릭하면 피드백 페이지로 이동하게 됩니다
<img width="979" height="724" alt="스크린샷 2025-07-18 163338" src="https://github.com/user-attachments/assets/ab215d4d-1c04-459a-8985-d6811b1099bf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * "MISSION_FEEDBACK" 유형의 알림을 지원하여, 해당 알림 클릭 시 미션 상세 페이지로 이동하도록 개선되었습니다.
  * "MISSION_FEEDBACK" 알림이 "활동" 카테고리로 분류됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->