### PR TITLE
[feat] 관리자 도메인의 전체 유저 통계 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.2",
+        "recharts": "^3.1.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^3.0.1",
         "styled-components": "^6.1.18",
@@ -1459,6 +1460,32 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.19",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
@@ -1746,6 +1773,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1790,6 +1829,69 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -2673,6 +2775,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -2699,6 +2922,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -2864,6 +3093,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.7",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.7.tgz",
+      "integrity": "sha512-ek/wWryKouBrZIjkwW2BFf91CWOIMvoy2AE5YYgUrfWsJQM2Su1LoLtrw8uusEpN9RfqLlV/0FVNjT0WMv8Bxw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.6",
@@ -3122,6 +3361,12 @@
       "version": "1.0.31",
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
       "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
+      "license": "MIT"
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
     },
     "node_modules/extend": {
@@ -3718,6 +3963,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/immutable": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
@@ -3757,6 +4012,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
       "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -7975,6 +8239,13 @@
         "react": "*"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-markdown": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.3.tgz",
@@ -8086,11 +8357,47 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.1.0.tgz",
+      "integrity": "sha512-NqAqQcGBmLrfDs2mHX/bz8jJCQtG2FeXfE0GqpZmIuXIjkpIwj8sd9ad0WyvKiBKPd8ZgNG0hL85c8sFDwascw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
     },
     "node_modules/refractor": {
       "version": "4.9.0",
@@ -8493,6 +8800,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -9095,6 +9408,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.2",
+    "recharts": "^3.1.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^3.0.1",
     "styled-components": "^6.1.18",

--- a/src/api/adminService.js
+++ b/src/api/adminService.js
@@ -1,5 +1,10 @@
 import api from './axiosInstance';
+
 const BASE = '/api/v1/admin/users';
+
+// ========================
+// 기본 사용자 관리 API
+// ========================
 
 export const getUsers = async (page = 0, size = 10) => {
   try {
@@ -54,76 +59,63 @@ export const changeUserRole = async (username, role) => {
     throw error;
   }
 };
-// 기존 adminService.js에 추가할 통계 관련 API 함수들
 
-// 기존 adminService.js에 추가할 함수들
-// (기존 import 및 함수들은 그대로 두고 아래 함수들만 추가)
+// ========================
+// 통계 관련 API
+// ========================
 
 /**
  * 전체 사용자 통계 조회
  */
 export const getUserStats = async () => {
-  alert('getUserStats 함수가 호출되었습니다!'); // 테스트용
-  
   try {
-    // 기본 관리자 API 사용 (정상 작동하는 것으로 확인됨)
-    const response = await api.get('/api/v1/admin/users', {
+    // 1. 사용자 목록 조회
+    const usersResponse = await api.get('/api/v1/admin/users', {
       params: { 
         page: 0, 
-        size: 200 // 전체 사용자를 확실히 포함하도록 더 크게 설정
+        size: 200
       }
     });
     
-    const users = response.data.data.content;
+    const users = usersResponse.data.data.content;
     
-    // API 응답 원본 확인
-    console.log('=== API 응답 원본 확인 ===');
-    console.log('response.data.data:', response.data.data);
-    console.log('content 길이:', response.data.data.content?.length);
-    console.log('totalElements:', response.data.data.totalElements);
-    console.log('totalPages:', response.data.data.totalPages);
-    console.log('페이지 정보:', {
-      number: response.data.data.number,
-      size: response.data.data.size,
-      numberOfElements: response.data.data.numberOfElements
-    });
+    // 2. 활성 사용자 통계 조회 (새로운 API 사용)
+    const activeStatsResponse = await api.get('/api/v1/admin/attendance/active-stats');
+    const activeStats = activeStatsResponse.data.data;
     
     // 통계 계산
     const totalUsers = users.length;
-    // 활성 사용자 기준: 레벨 2 이상 또는 포인트 50 이상
-    const activeUsers = users.filter(user => 
-      user.level >= 2 || user.point >= 50
-    ).length; 
+    const activeUsers = activeStats.activeUsers;
+
+    // 레벨별 분포 - 실제 데이터 사용
+    const levelDistribution = users.reduce((acc, user) => {
+      const level = user.level || 0;
+      acc[level] = (acc[level] || 0) + 1;
+      return acc;
+    }, {});
     
-    // 권한별 분포만 계산 (현재 사용 가능한 데이터)
+    // 포인트 구간별 분포 - 실제 데이터 사용
+    const pointRanges = {
+      '0-100': 0,
+      '101-500': 0,
+      '501-1000': 0,
+      '1000+': 0
+    };
+    
+    users.forEach(user => {
+      const points = user.point || 0;
+      if (points <= 100) pointRanges['0-100']++;
+      else if (points <= 500) pointRanges['101-500']++;
+      else if (points <= 1000) pointRanges['501-1000']++;
+      else pointRanges['1000+']++;
+    });
+    
+    // 권한별 분포
     const roleDistribution = users.reduce((acc, user) => {
       const role = user.role;
       acc[role] = (acc[role] || 0) + 1;
       return acc;
     }, {});
-    
-    // 레벨별 분포 - 실제 데이터 사용
-const levelDistribution = users.reduce((acc, user) => {
-  const level = user.level || 0;
-  acc[level] = (acc[level] || 0) + 1;
-  return acc;
-}, {});
-
-// 포인트 구간별 분포 - 실제 데이터 사용
-const pointRanges = {
-  '0-100': 0,
-  '101-500': 0,
-  '501-1000': 0,
-  '1000+': 0
-};
-
-users.forEach(user => {
-  const points = user.point || 0;
-  if (points <= 100) pointRanges['0-100']++;
-  else if (points <= 500) pointRanges['101-500']++;
-  else if (points <= 1000) pointRanges['501-1000']++;
-  else pointRanges['1000+']++;
-});
     
     return {
       totalUsers,
@@ -132,12 +124,11 @@ users.forEach(user => {
       pointDistribution: pointRanges,
       roleDistribution,
       users,
-      // 실제 데이터가 아님을 표시
-      isEstimated: true
+      activeUserRate: activeStats.activeUserRate,
+      baseDate: activeStats.baseDate
     };
   } catch (error) {
     console.error('사용자 통계 조회 실패:', error);
-    alert(`API 에러 발생: ${error.message}\n상태: ${error.response?.status}\n데이터: ${JSON.stringify(error.response?.data)}`);
     throw error;
   }
 };
@@ -188,29 +179,12 @@ export const getUserAttendanceStats = async (username) => {
 };
 
 /**
- * 월별 가입자 통계 (사용자 목록의 createdAt 기반)
- * 실제로는 백엔드에서 createdAt을 제공해야 하지만, 현재는 임시로 레벨 기반으로 추정
+ * 월별 가입자 통계 조회
  */
 export const getMonthlyRegistrationStats = async () => {
   try {
-    const response = await api.get('/api/v1/admin/users', {
-      params: { page: 0, size: 10000 }
-    });
-    
-    const users = response.data.data.content;
-    
-    // 임시: 레벨이 높을수록 오래된 사용자로 가정하여 월별 분포 생성
-    const monthlyStats = {};
-    const currentDate = new Date();
-    
-    // 최근 12개월 데이터 생성
-    for (let i = 11; i >= 0; i--) {
-      const date = new Date(currentDate.getFullYear(), currentDate.getMonth() - i, 1);
-      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
-      monthlyStats[key] = Math.floor(Math.random() * 20) + 5; // 임시 데이터
-    }
-    
-    return monthlyStats;
+    const response = await api.get('/api/v1/admin/users/monthly-stats');
+    return response.data.data;
   } catch (error) {
     console.error('월별 가입자 통계 조회 실패:', error);
     throw error;

--- a/src/api/adminService.js
+++ b/src/api/adminService.js
@@ -54,52 +54,76 @@ export const changeUserRole = async (username, role) => {
     throw error;
   }
 };
+// 기존 adminService.js에 추가할 통계 관련 API 함수들
+
+// 기존 adminService.js에 추가할 함수들
+// (기존 import 및 함수들은 그대로 두고 아래 함수들만 추가)
 
 /**
  * 전체 사용자 통계 조회
  */
 export const getUserStats = async () => {
+  alert('getUserStats 함수가 호출되었습니다!'); // 테스트용
+  
   try {
-    // 전체 사용자 목록을 가져와서 통계 계산
+    // 기본 관리자 API 사용 (정상 작동하는 것으로 확인됨)
     const response = await api.get('/api/v1/admin/users', {
-      params: { page: 0, size: 10000 } // 전체 데이터를 위해 큰 size 설정
+      params: { 
+        page: 0, 
+        size: 200 // 전체 사용자를 확실히 포함하도록 더 크게 설정
+      }
     });
     
     const users = response.data.data.content;
     
-    // 통계 계산
-    const totalUsers = users.length;
-    const activeUsers = users.filter(user => user.level >= 1).length; // 레벨 1 이상을 활성 사용자로 가정
-    
-    // 레벨별 분포
-    const levelDistribution = users.reduce((acc, user) => {
-      const level = user.level;
-      acc[level] = (acc[level] || 0) + 1;
-      return acc;
-    }, {});
-    
-    // 포인트 구간별 분포 (0-100, 101-500, 501-1000, 1000+)
-    const pointRanges = {
-      '0-100': 0,
-      '101-500': 0,
-      '501-1000': 0,
-      '1000+': 0
-    };
-    
-    users.forEach(user => {
-      const points = user.point || 0;
-      if (points <= 100) pointRanges['0-100']++;
-      else if (points <= 500) pointRanges['101-500']++;
-      else if (points <= 1000) pointRanges['501-1000']++;
-      else pointRanges['1000+']++;
+    // API 응답 원본 확인
+    console.log('=== API 응답 원본 확인 ===');
+    console.log('response.data.data:', response.data.data);
+    console.log('content 길이:', response.data.data.content?.length);
+    console.log('totalElements:', response.data.data.totalElements);
+    console.log('totalPages:', response.data.data.totalPages);
+    console.log('페이지 정보:', {
+      number: response.data.data.number,
+      size: response.data.data.size,
+      numberOfElements: response.data.data.numberOfElements
     });
     
-    // 권한별 분포
+    // 통계 계산
+    const totalUsers = users.length;
+    // 활성 사용자 기준: 레벨 2 이상 또는 포인트 50 이상
+    const activeUsers = users.filter(user => 
+      user.level >= 2 || user.point >= 50
+    ).length; 
+    
+    // 권한별 분포만 계산 (현재 사용 가능한 데이터)
     const roleDistribution = users.reduce((acc, user) => {
       const role = user.role;
       acc[role] = (acc[role] || 0) + 1;
       return acc;
     }, {});
+    
+    // 레벨별 분포 - 실제 데이터 사용
+const levelDistribution = users.reduce((acc, user) => {
+  const level = user.level || 0;
+  acc[level] = (acc[level] || 0) + 1;
+  return acc;
+}, {});
+
+// 포인트 구간별 분포 - 실제 데이터 사용
+const pointRanges = {
+  '0-100': 0,
+  '101-500': 0,
+  '501-1000': 0,
+  '1000+': 0
+};
+
+users.forEach(user => {
+  const points = user.point || 0;
+  if (points <= 100) pointRanges['0-100']++;
+  else if (points <= 500) pointRanges['101-500']++;
+  else if (points <= 1000) pointRanges['501-1000']++;
+  else pointRanges['1000+']++;
+});
     
     return {
       totalUsers,
@@ -107,10 +131,13 @@ export const getUserStats = async () => {
       levelDistribution,
       pointDistribution: pointRanges,
       roleDistribution,
-      users // 상세 분석용
+      users,
+      // 실제 데이터가 아님을 표시
+      isEstimated: true
     };
   } catch (error) {
     console.error('사용자 통계 조회 실패:', error);
+    alert(`API 에러 발생: ${error.message}\n상태: ${error.response?.status}\n데이터: ${JSON.stringify(error.response?.data)}`);
     throw error;
   }
 };
@@ -170,7 +197,7 @@ export const getMonthlyRegistrationStats = async () => {
       params: { page: 0, size: 10000 }
     });
     
-    const _users = response.data.data.content;
+    const users = response.data.data.content;
     
     // 임시: 레벨이 높을수록 오래된 사용자로 가정하여 월별 분포 생성
     const monthlyStats = {};

--- a/src/api/adminService.js
+++ b/src/api/adminService.js
@@ -54,3 +54,138 @@ export const changeUserRole = async (username, role) => {
     throw error;
   }
 };
+
+/**
+ * 전체 사용자 통계 조회
+ */
+export const getUserStats = async () => {
+  try {
+    // 전체 사용자 목록을 가져와서 통계 계산
+    const response = await api.get('/api/v1/admin/users', {
+      params: { page: 0, size: 10000 } // 전체 데이터를 위해 큰 size 설정
+    });
+    
+    const users = response.data.data.content;
+    
+    // 통계 계산
+    const totalUsers = users.length;
+    const activeUsers = users.filter(user => user.level >= 1).length; // 레벨 1 이상을 활성 사용자로 가정
+    
+    // 레벨별 분포
+    const levelDistribution = users.reduce((acc, user) => {
+      const level = user.level;
+      acc[level] = (acc[level] || 0) + 1;
+      return acc;
+    }, {});
+    
+    // 포인트 구간별 분포 (0-100, 101-500, 501-1000, 1000+)
+    const pointRanges = {
+      '0-100': 0,
+      '101-500': 0,
+      '501-1000': 0,
+      '1000+': 0
+    };
+    
+    users.forEach(user => {
+      const points = user.point || 0;
+      if (points <= 100) pointRanges['0-100']++;
+      else if (points <= 500) pointRanges['101-500']++;
+      else if (points <= 1000) pointRanges['501-1000']++;
+      else pointRanges['1000+']++;
+    });
+    
+    // 권한별 분포
+    const roleDistribution = users.reduce((acc, user) => {
+      const role = user.role;
+      acc[role] = (acc[role] || 0) + 1;
+      return acc;
+    }, {});
+    
+    return {
+      totalUsers,
+      activeUsers,
+      levelDistribution,
+      pointDistribution: pointRanges,
+      roleDistribution,
+      users // 상세 분석용
+    };
+  } catch (error) {
+    console.error('사용자 통계 조회 실패:', error);
+    throw error;
+  }
+};
+
+/**
+ * 특정 사용자의 출석 통계 조회
+ */
+export const getUserAttendanceStats = async (username) => {
+  try {
+    const response = await api.get('/api/v1/admin/attendance/dates', {
+      params: { username }
+    });
+    
+    const attendanceDates = response.data.data;
+    
+    // 출석 통계 계산
+    const totalAttendance = attendanceDates.length;
+    const currentMonth = new Date().getMonth() + 1;
+    const currentYear = new Date().getFullYear();
+    
+    const thisMonthAttendance = attendanceDates.filter(dateStr => {
+      const date = new Date(dateStr);
+      return date.getMonth() + 1 === currentMonth && date.getFullYear() === currentYear;
+    }).length;
+    
+    // 최근 30일 출석률
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    
+    const recentAttendance = attendanceDates.filter(dateStr => {
+      const date = new Date(dateStr);
+      return date >= thirtyDaysAgo;
+    }).length;
+    
+    const recentAttendanceRate = Math.round((recentAttendance / 30) * 100);
+    
+    return {
+      totalAttendance,
+      thisMonthAttendance,
+      recentAttendanceRate,
+      attendanceDates,
+      lastAttendance: attendanceDates[attendanceDates.length - 1] || null
+    };
+  } catch (error) {
+    console.error('사용자 출석 통계 조회 실패:', error);
+    throw error;
+  }
+};
+
+/**
+ * 월별 가입자 통계 (사용자 목록의 createdAt 기반)
+ * 실제로는 백엔드에서 createdAt을 제공해야 하지만, 현재는 임시로 레벨 기반으로 추정
+ */
+export const getMonthlyRegistrationStats = async () => {
+  try {
+    const response = await api.get('/api/v1/admin/users', {
+      params: { page: 0, size: 10000 }
+    });
+    
+    const _users = response.data.data.content;
+    
+    // 임시: 레벨이 높을수록 오래된 사용자로 가정하여 월별 분포 생성
+    const monthlyStats = {};
+    const currentDate = new Date();
+    
+    // 최근 12개월 데이터 생성
+    for (let i = 11; i >= 0; i--) {
+      const date = new Date(currentDate.getFullYear(), currentDate.getMonth() - i, 1);
+      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+      monthlyStats[key] = Math.floor(Math.random() * 20) + 5; // 임시 데이터
+    }
+    
+    return monthlyStats;
+  } catch (error) {
+    console.error('월별 가입자 통계 조회 실패:', error);
+    throw error;
+  }
+};

--- a/src/components/Admin/MonthlyRegistrationChart.jsx
+++ b/src/components/Admin/MonthlyRegistrationChart.jsx
@@ -1,0 +1,134 @@
+import React, { useState, useEffect } from 'react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { getMonthlyRegistrationStats } from '../../api/adminService';
+import styles from './MonthlyRegistrationChart.module.css';
+
+const MonthlyRegistrationChart = () => {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const monthlyStats = await getMonthlyRegistrationStats();
+        
+        const chartData = monthlyStats.map(stat => ({
+          month: stat.month,
+          count: stat.count,
+          growthRate: stat.growthRate,
+          displayMonth: formatMonth(stat.month)
+        }));
+        
+        setData(chartData);
+      } catch (err) {
+        setError('월별 가입자 데이터를 불러오는데 실패했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const formatMonth = (monthStr) => {
+    const [year, month] = monthStr.split('-');
+    return `${parseInt(month)}월`;
+  };
+
+  const CustomTooltip = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div className={styles.tooltip}>
+          <p className={styles.tooltipLabel}>{data.month}</p>
+          <p className={styles.tooltipValue}>
+            가입자: <span>{data.count}명</span>
+          </p>
+          {data.growthRate !== null && (
+            <p className={styles.tooltipGrowth}>
+              전월 대비: 
+              <span className={data.growthRate >= 0 ? styles.positive : styles.negative}>
+                {data.growthRate > 0 ? '+' : ''}{data.growthRate}%
+              </span>
+            </p>
+          )}
+        </div>
+      );
+    }
+    return null;
+  };
+
+  if (loading) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.loading}>월별 가입자 데이터 로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.error}>{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h3>월별 신규 가입자 추이</h3>
+      </div>
+      
+      <div className={styles.chartContainer}>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis 
+              dataKey="displayMonth" 
+              tick={{ fontSize: 12 }}
+              stroke="#666"
+            />
+            <YAxis 
+              tick={{ fontSize: 12 }}
+              stroke="#666"
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Line 
+              type="monotone" 
+              dataKey="count" 
+              stroke="#4F46E5" 
+              strokeWidth={3}
+              dot={{ fill: '#4F46E5', strokeWidth: 2, r: 4 }}
+              activeDot={{ r: 6, stroke: '#4F46E5', strokeWidth: 2, fill: '#fff' }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className={styles.summary}>
+        <div className={styles.summaryItem}>
+          <span className={styles.summaryLabel}>총 가입자 (12개월)</span>
+          <span className={styles.summaryValue}>
+            {data.reduce((sum, item) => sum + item.count, 0)}명
+          </span>
+        </div>
+        <div className={styles.summaryItem}>
+          <span className={styles.summaryLabel}>월 평균</span>
+          <span className={styles.summaryValue}>
+            {Math.round(data.reduce((sum, item) => sum + item.count, 0) / data.length)}명
+          </span>
+        </div>
+        <div className={styles.summaryItem}>
+          <span className={styles.summaryLabel}>최고 기록</span>
+          <span className={styles.summaryValue}>
+            {Math.max(...data.map(item => item.count))}명
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MonthlyRegistrationChart;

--- a/src/components/Admin/MonthlyRegistrationChart.module.css
+++ b/src/components/Admin/MonthlyRegistrationChart.module.css
@@ -1,0 +1,108 @@
+.container {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  margin: 20px 0;
+}
+
+.header {
+  margin-bottom: 20px;
+}
+
+.header h3 {
+  margin: 0;
+  color: #1f2937;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.chartContainer {
+  margin: 20px 0;
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  color: #dc2626;
+  font-size: 14px;
+}
+
+.tooltip {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.tooltipLabel {
+  margin: 0 0 4px 0;
+  font-weight: 600;
+  color: #1f2937;
+  font-size: 13px;
+}
+
+.tooltipValue {
+  margin: 0 0 4px 0;
+  font-size: 13px;
+  color: #4b5563;
+}
+
+.tooltipValue span {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.tooltipGrowth {
+  margin: 0;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.tooltipGrowth .positive {
+  color: #059669;
+  font-weight: 600;
+}
+
+.tooltipGrowth .negative {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.summary {
+  display: flex;
+  justify-content: space-around;
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.summaryItem {
+  text-align: center;
+}
+
+.summaryLabel {
+  display: block;
+  font-size: 12px;
+  color: #6b7280;
+  margin-bottom: 4px;
+}
+
+.summaryValue {
+  display: block;
+  font-size: 16px;
+  font-weight: 600;
+  color: #1f2937;
+}

--- a/src/layouts/AdminLayout.jsx
+++ b/src/layouts/AdminLayout.jsx
@@ -5,7 +5,7 @@ import useTokenPayload from '../stores/tokenPayloadStore';
 import { getCurrentUser } from '../api/userService';
 import { jwtDecode } from 'jwt-decode';
 import styles from './AdminLayout.module.scss';
-import { FaUsers, FaHouse, FaListCheck, FaStore } from 'react-icons/fa6'; // 아이콘 import 추가
+import { FaUsers, FaHouse, FaListCheck, FaStore, FaChartBar } from 'react-icons/fa6'; // FaChartBar 추가
 
 export default function AdminLayout() {
   const userInfo = useUserStore((state) => state.userInfo);
@@ -103,6 +103,18 @@ export default function AdminLayout() {
               <FaUsers />
             </span>
             회원 관리
+          </NavLink>
+
+          <NavLink
+            to="/admin/stats"
+            className={({ isActive }) =>
+              `${styles.navItem} ${isActive ? styles.active : ''}`
+            }
+          >
+            <span className={styles.navIcon}>
+              <FaChartBar />
+            </span>
+            사용자 통계
           </NavLink>
           
           <NavLink

--- a/src/pages/admin/AdminStatsDashboard.jsx
+++ b/src/pages/admin/AdminStatsDashboard.jsx
@@ -2,51 +2,36 @@ import React, { useState, useEffect } from 'react';
 import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line } from 'recharts';
 import { getUserStats } from '../../api/adminService';
 import styles from './AdminStatsDashboard.module.scss';
+import MonthlyRegistrationChart from '../../components/Admin/MonthlyRegistrationChart';
 
 const AdminStatsDashboard = () => {
   const [statsData, setStatsData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  console.log('=== AdminStatsDashboard 컴포넌트 마운트됨 ===');
-
   useEffect(() => {
     let isMounted = true; // cleanup 플래그
     
-    console.log('=== useEffect 실행됨 ===');
-    
     const loadData = async () => {
-      try {
-        console.log('=== API 호출 시작 ===');
-        const data = await getUserStats();
-        console.log('=== API 호출 성공 ===');
-        console.log('총 사용자:', data.totalUsers);
-        console.log('활성 사용자:', data.activeUsers); 
-        console.log('레벨별 분포:', data.levelDistribution);
-        console.log('포인트 분포:', data.pointDistribution);
-        console.log('권한별 분포:', data.roleDistribution);
-        if (isMounted) {
-          setStatsData(data);
-        }
-      } catch (err) {
-        console.log('=== API 호출 실패 ===', err);
-        if (isMounted) {
-          setError('통계 데이터를 불러오는데 실패했습니다.');
-          console.error('Stats fetch error:', err);
-        }
-      } finally {
-        if (isMounted) {
-          setLoading(false);
-        }
+    try {
+      const data = await getUserStats();
+      if (isMounted) {
+        setStatsData(data);
       }
-    };
+    } catch (err) {
+      if (isMounted) {
+        setError('통계 데이터를 불러오는데 실패했습니다.');
+      }
+    } finally {
+      if (isMounted) {
+        setLoading(false);
+      }
+    }
+  };
 
-    loadData();
-
-    return () => {
-      isMounted = false; // 컴포넌트 언마운트 시 플래그 설정
-    };
-  }, []);
+  loadData();
+  return () => { isMounted = false; };
+}, []);
 
   if (loading) {
     return (
@@ -267,21 +252,8 @@ const AdminStatsDashboard = () => {
           </div>
         </div>
 
-        {/* 월별 가입자 추이 - 실제 데이터 준비 후 활성화 */}
-        {/* 
-        <div className={styles.chartCard}>
-          <h3>월별 가입자 추이</h3>
-          <ResponsiveContainer width="100%" height={300}>
-            <LineChart data={monthlyData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="month" />
-              <YAxis />
-              <Tooltip />
-              <Line type="monotone" dataKey="count" stroke="#00C49F" strokeWidth={2} />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-        */}
+        {/* 월별 가입자 추이*/}
+        <MonthlyRegistrationChart />
       </div>
     </div>
   );

--- a/src/pages/admin/AdminStatsDashboard.jsx
+++ b/src/pages/admin/AdminStatsDashboard.jsx
@@ -1,0 +1,250 @@
+import React, { useState, useEffect } from 'react';
+import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line } from 'recharts';
+import { getUserStats, getMonthlyRegistrationStats } from '../../api/adminService';
+import styles from './AdminStatsDashboard.module.scss';
+
+const AdminStatsDashboard = () => {
+  const [statsData, setStatsData] = useState(null);
+  const [monthlyData, setMonthlyData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchStatsData();
+    fetchMonthlyData();
+  }, []);
+
+  const fetchStatsData = async () => {
+    try {
+      const data = await getUserStats();
+      setStatsData(data);
+    } catch (err) {
+      setError('통계 데이터를 불러오는데 실패했습니다.');
+      console.error('Stats fetch error:', err);
+    }
+  };
+
+  const fetchMonthlyData = async () => {
+    try {
+      const data = await getMonthlyRegistrationStats();
+      const chartData = Object.entries(data).map(([month, count]) => ({
+        month,
+        count
+      }));
+      setMonthlyData(chartData);
+    } catch (err) {
+      console.error('Monthly data fetch error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return <div className={styles.loading}>통계 데이터를 불러오는 중...</div>;
+  }
+
+  if (error) {
+    return <div className={styles.error}>{error}</div>;
+  }
+
+  if (!statsData) {
+    return <div className={styles.error}>데이터를 불러올 수 없습니다.</div>;
+  }
+
+  // 차트 데이터 준비
+  const levelChartData = Object.entries(statsData.levelDistribution || {}).map(([level, count]) => ({
+    level: `레벨 ${level}`,
+    count
+  }));
+
+  const pointChartData = Object.entries(statsData.pointDistribution || {}).map(([range, count]) => ({
+    range,
+    count
+  }));
+
+  const roleChartData = Object.entries(statsData.roleDistribution || {}).map(([role, count]) => ({
+    role: role === 'USER' ? '일반회원' : role === 'ADMIN' ? '관리자' : role,
+    count
+  }));
+
+  // 파이차트 색상
+  const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8', '#82CA9D'];
+
+  const RADIAN = Math.PI / 180;
+  const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent }) => {
+    const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
+    const x = cx + radius * Math.cos(-midAngle * RADIAN);
+    const y = cy + radius * Math.sin(-midAngle * RADIAN);
+
+    return (
+      <text 
+        x={x} 
+        y={y} 
+        fill="white" 
+        textAnchor={x > cx ? 'start' : 'end'} 
+        dominantBaseline="central"
+        fontSize="12"
+        fontWeight="bold"
+      >
+        {`${(percent * 100).toFixed(0)}%`}
+      </text>
+    );
+  };
+
+  return (
+    <div className={styles.adminStats}>
+      <div className={styles.header}>
+        <h1>사용자 통계 대시보드</h1>
+        <p>전체 사용자 현황 및 활동 통계</p>
+      </div>
+
+      {/* 요약 카드 */}
+      <div className={styles.summaryCards}>
+        <div className={styles.card}>
+          <div className={styles.cardIcon}>👥</div>
+          <div className={styles.cardContent}>
+            <h3>총 사용자</h3>
+            <p className={styles.number}>{statsData.totalUsers.toLocaleString()}</p>
+          </div>
+        </div>
+        <div className={styles.card}>
+          <div className={styles.cardIcon}>⚡</div>
+          <div className={styles.cardContent}>
+            <h3>활성 사용자</h3>
+            <p className={styles.number}>{statsData.activeUsers.toLocaleString()}</p>
+            <span className={styles.percentage}>
+              ({statsData.totalUsers > 0 
+                ? ((statsData.activeUsers / statsData.totalUsers) * 100).toFixed(1)
+                : 0}%)
+            </span>
+          </div>
+        </div>
+        <div className={styles.card}>
+          <div className={styles.cardIcon}>📊</div>
+          <div className={styles.cardContent}>
+            <h3>평균 레벨</h3>
+            <p className={styles.number}>
+              {statsData.totalUsers > 0 
+                ? (Object.entries(statsData.levelDistribution)
+                    .reduce((sum, [level, count]) => sum + (parseInt(level) * count), 0) / statsData.totalUsers).toFixed(1)
+                : 0
+              }
+            </p>
+          </div>
+        </div>
+        <div className={styles.card}>
+          <div className={styles.cardIcon}>🎯</div>
+          <div className={styles.cardContent}>
+            <h3>총 포인트</h3>
+            <p className={styles.number}>
+              {statsData.users.reduce((sum, user) => sum + (user.point || 0), 0).toLocaleString()}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* 차트 섹션 */}
+      <div className={styles.chartsGrid}>
+        {/* 레벨 분포 */}
+        <div className={styles.chartCard}>
+          <h3>레벨별 사용자 분포</h3>
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={levelChartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="level" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="count" fill="#0088FE" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* 포인트 분포 */}
+        <div className={styles.chartCard}>
+          <h3>포인트 구간별 분포</h3>
+          <ResponsiveContainer width="100%" height={300}>
+            <PieChart>
+              <Pie
+                data={pointChartData}
+                cx="50%"
+                cy="50%"
+                labelLine={false}
+                label={renderCustomizedLabel}
+                outerRadius={80}
+                fill="#8884d8"
+                dataKey="count"
+              >
+                {pointChartData.map((entry, index) => (
+                  <Cell key={`point-cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                ))}
+              </Pie>
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+          <div className={styles.legend}>
+            {pointChartData.map((item, index) => (
+              <div key={item.range} className={styles.legendItem}>
+                <div 
+                  className={styles.legendColor} 
+                  style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                />
+                <span>{item.range}: {item.count}명</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* 권한별 분포 */}
+        <div className={styles.chartCard}>
+          <h3>권한별 사용자 분포</h3>
+          <ResponsiveContainer width="100%" height={300}>
+            <PieChart>
+              <Pie
+                data={roleChartData}
+                cx="50%"
+                cy="50%"
+                labelLine={false}
+                label={renderCustomizedLabel}
+                outerRadius={80}
+                fill="#8884d8"
+                dataKey="count"
+              >
+                {roleChartData.map((entry, index) => (
+                  <Cell key={`role-cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                ))}
+              </Pie>
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+          <div className={styles.legend}>
+            {roleChartData.map((item, index) => (
+              <div key={item.role} className={styles.legendItem}>
+                <div 
+                  className={styles.legendColor} 
+                  style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                />
+                <span>{item.role}: {item.count}명</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* 월별 가입자 추이 */}
+        <div className={styles.chartCard}>
+          <h3>월별 가입자 추이</h3>
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={monthlyData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="month" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="count" stroke="#00C49F" strokeWidth={2} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminStatsDashboard;

--- a/src/pages/admin/AdminStatsDashboard.jsx
+++ b/src/pages/admin/AdminStatsDashboard.jsx
@@ -1,61 +1,96 @@
 import React, { useState, useEffect } from 'react';
 import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line } from 'recharts';
-import { getUserStats, getMonthlyRegistrationStats } from '../../api/adminService';
+import { getUserStats } from '../../api/adminService';
 import styles from './AdminStatsDashboard.module.scss';
 
 const AdminStatsDashboard = () => {
   const [statsData, setStatsData] = useState(null);
-  const [monthlyData, setMonthlyData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
+  console.log('=== AdminStatsDashboard 컴포넌트 마운트됨 ===');
+
   useEffect(() => {
-    fetchStatsData();
-    fetchMonthlyData();
+    let isMounted = true; // cleanup 플래그
+    
+    console.log('=== useEffect 실행됨 ===');
+    
+    const loadData = async () => {
+      try {
+        console.log('=== API 호출 시작 ===');
+        const data = await getUserStats();
+        console.log('=== API 호출 성공 ===');
+        console.log('총 사용자:', data.totalUsers);
+        console.log('활성 사용자:', data.activeUsers); 
+        console.log('레벨별 분포:', data.levelDistribution);
+        console.log('포인트 분포:', data.pointDistribution);
+        console.log('권한별 분포:', data.roleDistribution);
+        if (isMounted) {
+          setStatsData(data);
+        }
+      } catch (err) {
+        console.log('=== API 호출 실패 ===', err);
+        if (isMounted) {
+          setError('통계 데이터를 불러오는데 실패했습니다.');
+          console.error('Stats fetch error:', err);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadData();
+
+    return () => {
+      isMounted = false; // 컴포넌트 언마운트 시 플래그 설정
+    };
   }, []);
 
-  const fetchStatsData = async () => {
-    try {
-      const data = await getUserStats();
-      setStatsData(data);
-    } catch (err) {
-      setError('통계 데이터를 불러오는데 실패했습니다.');
-      console.error('Stats fetch error:', err);
-    }
-  };
-
-  const fetchMonthlyData = async () => {
-    try {
-      const data = await getMonthlyRegistrationStats();
-      const chartData = Object.entries(data).map(([month, count]) => ({
-        month,
-        count
-      }));
-      setMonthlyData(chartData);
-    } catch (err) {
-      console.error('Monthly data fetch error:', err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
   if (loading) {
-    return <div className={styles.loading}>통계 데이터를 불러오는 중...</div>;
+    return (
+      <div className={styles.loading}>
+        <div>통계 데이터를 불러오는 중...</div>
+        <div style={{ fontSize: '14px', color: '#6c757d', marginTop: '8px' }}>
+          사용자별 출석 정보를 조회하고 있습니다. 잠시만 기다려주세요.
+        </div>
+        <div style={{ fontSize: '12px', color: '#dc3545', marginTop: '8px' }}>
+          DEBUG: 로딩 상태 - API 호출 중
+        </div>
+      </div>
+    );
   }
 
   if (error) {
-    return <div className={styles.error}>{error}</div>;
+    return (
+      <div className={styles.error}>
+        {error}
+        <div style={{ fontSize: '12px', marginTop: '8px' }}>
+          DEBUG: 에러 상태 - {error}
+        </div>
+      </div>
+    );
   }
 
   if (!statsData) {
-    return <div className={styles.error}>데이터를 불러올 수 없습니다.</div>;
+    return (
+      <div className={styles.error}>
+        데이터를 불러올 수 없습니다.
+        <div style={{ fontSize: '12px', marginTop: '8px' }}>
+          DEBUG: statsData가 null입니다.
+        </div>
+      </div>
+    );
   }
 
   // 차트 데이터 준비
-  const levelChartData = Object.entries(statsData.levelDistribution || {}).map(([level, count]) => ({
-    level: `레벨 ${level}`,
-    count
-  }));
+  const levelChartData = Object.entries(statsData.levelDistribution || {})
+    .sort(([a], [b]) => parseInt(a) - parseInt(b)) // 레벨 순으로 정렬
+    .map(([level, count]) => ({
+      level: `레벨 ${level}`,
+      count
+    }));
 
   const pointChartData = Object.entries(statsData.pointDistribution || {}).map(([range, count]) => ({
     range,
@@ -117,6 +152,9 @@ const AdminStatsDashboard = () => {
                 ? ((statsData.activeUsers / statsData.totalUsers) * 100).toFixed(1)
                 : 0}%)
             </span>
+            <div className={styles.criteria}>
+              {statsData.activeUsersCriteria || '최근 30일 내 출석'}
+            </div>
           </div>
         </div>
         <div className={styles.card}>
@@ -229,7 +267,8 @@ const AdminStatsDashboard = () => {
           </div>
         </div>
 
-        {/* 월별 가입자 추이 */}
+        {/* 월별 가입자 추이 - 실제 데이터 준비 후 활성화 */}
+        {/* 
         <div className={styles.chartCard}>
           <h3>월별 가입자 추이</h3>
           <ResponsiveContainer width="100%" height={300}>
@@ -242,6 +281,7 @@ const AdminStatsDashboard = () => {
             </LineChart>
           </ResponsiveContainer>
         </div>
+        */}
       </div>
     </div>
   );

--- a/src/pages/admin/AdminStatsDashboard.jsx
+++ b/src/pages/admin/AdminStatsDashboard.jsx
@@ -158,7 +158,7 @@ const AdminStatsDashboard = () => {
         <div className={styles.card}>
           <div className={styles.cardIcon}>🎯</div>
           <div className={styles.cardContent}>
-            <h3>총 포인트</h3>
+            <h3>총 구름조각</h3>
             <p className={styles.number}>
               {statsData.users.reduce((sum, user) => sum + (user.point || 0), 0).toLocaleString()}
             </p>
@@ -184,7 +184,7 @@ const AdminStatsDashboard = () => {
 
         {/* 포인트 분포 */}
         <div className={styles.chartCard}>
-          <h3>포인트 구간별 분포</h3>
+          <h3>구름조각 구간별 분포</h3>
           <ResponsiveContainer width="100%" height={300}>
             <PieChart>
               <Pie

--- a/src/pages/admin/AdminStatsDashboard.module.scss
+++ b/src/pages/admin/AdminStatsDashboard.module.scss
@@ -1,0 +1,201 @@
+.adminStats {
+  padding: 24px;
+  background-color: #f8f9fa;
+  min-height: 100vh;
+
+  .header {
+    margin-bottom: 32px;
+    
+    h1 {
+      font-size: 28px;
+      font-weight: 700;
+      color: #2c3e50;
+      margin-bottom: 8px;
+    }
+    
+    p {
+      color: #6c757d;
+      font-size: 16px;
+      margin: 0;
+    }
+  }
+
+  .summaryCards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+    margin-bottom: 32px;
+
+    .card {
+      background: white;
+      border-radius: 12px;
+      padding: 24px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      border: 1px solid #e9ecef;
+      transition: transform 0.2s ease-in-out;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+
+      &:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+      }
+
+      .cardIcon {
+        font-size: 32px;
+        width: 56px;
+        height: 56px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        border-radius: 12px;
+        color: white;
+      }
+
+      .cardContent {
+        flex: 1;
+
+        h3 {
+          font-size: 14px;
+          font-weight: 600;
+          color: #6c757d;
+          margin: 0 0 8px 0;
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
+        }
+
+        .number {
+          font-size: 28px;
+          font-weight: 700;
+          color: #2c3e50;
+          margin: 0;
+          line-height: 1.2;
+        }
+
+        .percentage {
+          font-size: 12px;
+          color: #28a745;
+          font-weight: 500;
+        }
+      }
+    }
+  }
+
+  .chartsGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+    gap: 24px;
+
+    .chartCard {
+      background: white;
+      border-radius: 12px;
+      padding: 24px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      border: 1px solid #e9ecef;
+
+      h3 {
+        font-size: 18px;
+        font-weight: 600;
+        color: #2c3e50;
+        margin: 0 0 20px 0;
+        padding-bottom: 12px;
+        border-bottom: 2px solid #f8f9fa;
+      }
+
+      .legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 16px;
+        justify-content: center;
+
+        .legendItem {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-size: 12px;
+          color: #6c757d;
+
+          .legendColor {
+            width: 12px;
+            height: 12px;
+            border-radius: 2px;
+          }
+        }
+      }
+    }
+  }
+
+  .loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 400px;
+    font-size: 18px;
+    color: #6c757d;
+  }
+
+  .error {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 400px;
+    font-size: 18px;
+    color: #dc3545;
+    background: #f8d7da;
+    border: 1px solid #f5c6cb;
+    border-radius: 8px;
+    margin: 20px;
+  }
+}
+
+// 반응형 디자인
+@media (max-width: 768px) {
+  .adminStats {
+    padding: 16px;
+
+    .summaryCards {
+      grid-template-columns: 1fr;
+      gap: 16px;
+
+      .card {
+        padding: 20px;
+        
+        .cardIcon {
+          font-size: 24px;
+          width: 48px;
+          height: 48px;
+        }
+
+        .cardContent {
+          .number {
+            font-size: 24px;
+          }
+        }
+      }
+    }
+
+    .chartsGrid {
+      grid-template-columns: 1fr;
+      gap: 20px;
+
+      .chartCard {
+        padding: 20px;
+
+        h3 {
+          font-size: 16px;
+        }
+      }
+    }
+  }
+}
+
+@media (max-width: 1200px) {
+  .adminStats {
+    .chartsGrid {
+      grid-template-columns: 1fr;
+    }
+  }
+}

--- a/src/routes/admin.routes.jsx
+++ b/src/routes/admin.routes.jsx
@@ -3,6 +3,7 @@ import AdminUsersList   from '../pages/admin/AdminUsersList';
 import AdminUserDetail  from '../pages/admin/AdminUserDetail';
 import AdminShopPage from "../pages/admin/AdminShopPage";
 import AdminQuestPage from "../pages/admin/AdminQuestPage";
+import AdminStatsDashboard from '../pages/admin/AdminStatsDashboard';
 
 export default [
   {
@@ -13,6 +14,7 @@ export default [
       { path: 'users/:username', element: <AdminUserDetail /> },
       { path: "quest", element: <AdminQuestPage /> },
       { path: "shop", element: <AdminShopPage /> },
+      { path: "stats", element: <AdminStatsDashboard /> },
     ],
   },
 ];


### PR DESCRIPTION
### 주요 변경점
- 관리자 도메인의 유저 통계 페이지 구현
1. 전체 사용자 수
2. 활성 사용자 수 (활성 사용자 == 최근 30일 이내에 출석체크한 사용자, attendance 도메인 연결)
3. 전체 유저의 평균 레벨
4. 모든 유저의 총 구름조각 합
5. 레벨별 사용자 분표 막대 표
6. 구름조각 구간별 분포 원형 표
7. 권한별 사용자 분포 원형 표
8. 월별 신규 가입자 추이 선형 표 
---
### 추후 변경할 점
- 백엔드에서 통계 하나로 내서 프론트에 깔끔하게 보낼 수 있게 추후 리팩토링 하겠습니다.
---
### 사진
<img width="1624" height="1056" alt="스크린샷 2025-07-21 오전 8 38 23" src="https://github.com/user-attachments/assets/e4d2ab8f-9fb5-4337-b62c-6a4c67553422" />
<img width="1624" height="1056" alt="스크린샷 2025-07-21 오전 8 38 41" src="https://github.com/user-attachments/assets/ead415e7-039a-490d-932d-023e6d0e0eaf" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자 페이지에 사용자 통계 대시보드가 추가되었습니다.
  * 월별 회원 가입 추이 차트와 사용자 레벨, 포인트, 역할 분포 등 다양한 통계 시각화가 제공됩니다.
  * 관리자 사이드바에 "사용자 통계" 메뉴가 추가되었습니다.

* **스타일**
  * 관리자 통계 대시보드와 월별 가입 차트에 맞춤형 스타일이 적용되었습니다.

* **기타**
  * 통계 시각화를 위해 `recharts` 라이브러리가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->