### PR TITLE
[feat] 지도 중심 회사 검색을 위한 위도/경도 기능 추가

### DIFF
--- a/src/components/common/btn/CommonButton.jsx
+++ b/src/components/common/btn/CommonButton.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import styles from './CommonButton.module.scss';
+
+function CommonButton({ 
+  onClick, 
+  children, 
+  className, 
+  backgroundColor,
+  color,
+  borderRadius,
+  padding,
+  border,
+  hoverBackgroundColor,
+  hoverColor,
+  ...props 
+}) {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const baseStyle = {
+    backgroundColor,
+    color,
+    borderRadius,
+    padding,
+    border,
+  };
+
+  // hover props가 제공되었을 때만 hover 스타일을 만듭니다.
+  const hoverStyle = {
+    backgroundColor: hoverBackgroundColor,
+    color: hoverColor,
+  };
+
+  // isHovered 상태에 따라 적용할 최종 스타일을 결정합니다.
+  // hover props가 없는 경우, SCSS 파일의 :hover 스타일이 적용됩니다.
+  const currentStyle = isHovered
+    ? { ...baseStyle, ...hoverStyle }
+    : baseStyle;
+
+  return (
+    <button
+      className={`${styles.commonButton} ${className || ''}`}
+      style={currentStyle}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onClick={onClick}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default CommonButton;

--- a/src/components/common/btn/CommonButton.jsx
+++ b/src/components/common/btn/CommonButton.jsx
@@ -24,16 +24,13 @@ function CommonButton({
     border,
   };
 
-  // hover props가 제공되었을 때만 hover 스타일을 만듭니다.
-  const hoverStyle = {
-    backgroundColor: hoverBackgroundColor,
-    color: hoverColor,
-  };
-
-  // isHovered 상태에 따라 적용할 최종 스타일을 결정합니다.
-  // hover props가 없는 경우, SCSS 파일의 :hover 스타일이 적용됩니다.
-  const currentStyle = isHovered
-    ? { ...baseStyle, ...hoverStyle }
+  // hover props가 제공되었을 때만 hover 스타일을 적용합니다.
+  const currentStyle = isHovered && (hoverBackgroundColor || hoverColor)
+    ? {
+        ...baseStyle,
+        ...(hoverBackgroundColor && { backgroundColor: hoverBackgroundColor }),
+        ...(hoverColor && { color: hoverColor }),
+      }
     : baseStyle;
 
   return (

--- a/src/components/common/btn/CommonButton.module.scss
+++ b/src/components/common/btn/CommonButton.module.scss
@@ -1,0 +1,20 @@
+.commonButton {
+  background: rgba(255, 255, 255, 0.9);
+  color: #000;
+  padding: 7px 18px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 15px;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.11);
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px; /* 아이콘과 텍스트 사이의 간격 */
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 1);
+  }
+}

--- a/src/components/recruitment/recruitment_map/MapBoundsDisplay.jsx
+++ b/src/components/recruitment/recruitment_map/MapBoundsDisplay.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import styles from "./MapBoundsDisplay.module.scss";
+
+function MapBoundsDisplay({ bounds }) {
+  if (!bounds) {
+    return null;
+  }
+
+  const formatCoord = (coord) => {
+    if (
+      !coord ||
+      typeof coord.lat !== "number" ||
+      typeof coord.lng !== "number"
+    ) {
+      return "N/A";
+    }
+    return `Lat: ${coord.lat.toFixed(6)}, Lng: ${coord.lng.toFixed(6)}`;
+  };
+
+  return (
+    <div className={styles.boundsContainer}>
+      {bounds.diagonalDistance && (
+        <div className={styles.boundItem}>
+          <strong>현재 지도 범위 대각선 거리:</strong> {bounds.diagonalDistance}
+        </div>
+      )}
+      <div className={styles.boundItem}>
+        <strong>NE:</strong> {formatCoord(bounds.northEast)}
+      </div>
+      <div className={styles.boundItem}>
+        <strong>NW:</strong> {formatCoord(bounds.northWest)}
+      </div>
+      <div className={styles.boundItem}>
+        <strong>SE:</strong> {formatCoord(bounds.southEast)}
+      </div>
+      <div className={styles.boundItem}>
+        <strong>SW:</strong> {formatCoord(bounds.southWest)}
+      </div>
+    </div>
+  );
+}
+
+export default MapBoundsDisplay;

--- a/src/components/recruitment/recruitment_map/MapBoundsDisplay.module.scss
+++ b/src/components/recruitment/recruitment_map/MapBoundsDisplay.module.scss
@@ -1,0 +1,20 @@
+.boundsContainer {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background-color: rgba(255, 255, 255, 0.8);
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+  z-index: 1000; // Ensure it's above the map
+  font-family: monospace;
+  font-size: 12px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+.boundItem {
+  margin-bottom: 5px;
+  &:last-child {
+    margin-bottom: 0;
+  }
+}

--- a/src/components/recruitment/recruitment_map/MapContainer.jsx
+++ b/src/components/recruitment/recruitment_map/MapContainer.jsx
@@ -41,11 +41,8 @@ function MapContainer({
     const sw = newBounds.getSouthWest();
     const ne = newBounds.getNorthEast();
 
-    // 대각선 거리 계산
-    const polyline = new window.kakao.maps.Polyline({
-      path: [sw, ne],
-    });
-    const distanceInMeters = polyline.getLength();
+    // 대각선 거리 계산 (Haversine 공식 사용)
+    const distanceInMeters = window.kakao.maps.geometry.computeDistanceBetween(sw, ne);
     const distanceInKm = distanceInMeters / 1000;
 
     let displayDistance;

--- a/src/components/recruitment/recruitment_map/MapContainer.jsx
+++ b/src/components/recruitment/recruitment_map/MapContainer.jsx
@@ -1,42 +1,112 @@
-import React from "react";
+import React, { useEffect, useState, useRef } from "react";
 import {
   Map as KakaoMap,
   MapMarker,
   CustomOverlayMap,
+  Rectangle,
   useKakaoLoader,
 } from "react-kakao-maps-sdk";
 import styles from "./MapContainer.module.scss";
+import CommonButton from "../../common/btn/CommonButton";
+import { VscDebugRestart } from "react-icons/vsc";
 
-function MapContainer({ jobs, selectedJob, onSelectJob, mapCenter }) {
+function MapContainer({
+  onSearchCurrentMap,
+
+  jobs,
+  selectedJob,
+  onSelectJob,
+  onBoundsChange,
+}) {
   const [loading, error] = useKakaoLoader({
     appkey: import.meta.env.VITE_KAKAO_API_KEY, // .env 파일의 API 키
     libraries: ["clusterer", "drawing", "services"],
   });
 
-  const [map, setMap] = React.useState(null);
+  const [map, setMap] = useState(null);
+  const [mapCenter, setMapCenter] = useState({ lat: 37.5665, lng: 126.978 });
+  const [isSearchButtonVisible, setIsSearchButtonVisible] = useState(false);
+  const isInitialLoad = useRef(true);
 
-  React.useEffect(() => {
+  // 지도 중심좌표 이동 로직
+  useEffect(() => {
     if (map && mapCenter) {
       map.setCenter(new window.kakao.maps.LatLng(mapCenter.lat, mapCenter.lng));
     }
   }, [map, mapCenter]);
 
+  // 지도 경계 변경 핸들러
+  const handleBoundsChanged = (mapInstance) => {
+    const newBounds = mapInstance.getBounds();
+    const sw = newBounds.getSouthWest();
+    const ne = newBounds.getNorthEast();
+
+    // 대각선 거리 계산
+    const polyline = new window.kakao.maps.Polyline({
+      path: [sw, ne],
+    });
+    const distanceInMeters = polyline.getLength();
+    const distanceInKm = distanceInMeters / 1000;
+
+    let displayDistance;
+    if (distanceInKm > 3) {
+      displayDistance = "3km 초과";
+    } else {
+      displayDistance = `${distanceInKm.toFixed(2)}km`;
+    }
+
+    const boundingBox = {
+      northEast: { lat: ne.getLat(), lng: ne.getLng() },
+      southWest: { lat: sw.getLat(), lng: sw.getLng() },
+      northWest: { lat: ne.getLat(), lng: sw.getLng() },
+      southEast: { lat: sw.getLat(), lng: ne.getLng() },
+      diagonalDistance: displayDistance,
+    };
+    onBoundsChange(boundingBox);
+    if (!isInitialLoad.current) {
+      setIsSearchButtonVisible(true);
+    }
+  };
+
+  // 지도 로딩이 완료된 후, 첫 경계를 설정하는 로직
+  useEffect(() => {
+    if (!map) return;
+    handleBoundsChanged(map);
+    isInitialLoad.current = false;
+  }, [map]);
+
+  const handleSearchButtonClick = () => {
+    if (onSearchCurrentMap) {
+      onSearchCurrentMap();
+    }
+    setIsSearchButtonVisible(false);
+  };
+
   if (loading) return <div>로딩 중...</div>;
-  if (error) return <div>에러 발생: {error}</div>;
+  if (error) return <div>에러 발생: {error.message}</div>;
 
   return (
     <div className={styles.mapContainer}>
+      {isSearchButtonVisible && (
+        <CommonButton
+          className={styles.mapSearchButton}
+          onClick={handleSearchButtonClick}
+        >
+          <VscDebugRestart />현 지도에 검색
+        </CommonButton>
+      )}
       <KakaoMap
         center={mapCenter}
         style={{ width: "100%", height: "100%" }}
         level={8}
-        onCreate={setMap}
+        onCreate={setMap} // onCreate에서는 map 객체만 설정합니다.
+        onIdle={handleBoundsChanged} // 지도 움직임이 멈췄을 때만 경계를 업데이트합니다.
       >
         {jobs.map((job) => (
           <MapMarker
             key={job.id || `${job.company}-${job.title}-${job.lat}-${job.lng}`}
-            position={{ lat: job.lat, lng: job.lng }} // 마커를 표시할 위치
-            onClick={() => onSelectJob(job)} // 마커에 클릭 이벤트 등록
+            position={{ lat: job.lat, lng: job.lng }}
+            onClick={() => onSelectJob(job)}
           />
         ))}
 

--- a/src/components/recruitment/recruitment_map/MapContainer.module.scss
+++ b/src/components/recruitment/recruitment_map/MapContainer.module.scss
@@ -1,7 +1,16 @@
 .mapContainer {
+  position: relative; /* 자식 요소의 absolute 포지셔닝을 위해 필요 */
   flex: 2;
   width: 100%;
   height: 100%;
+}
+
+.mapSearchButton {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
 }
 
 .overlay {

--- a/src/pages/recruitment/RecruitmentMap.jsx
+++ b/src/pages/recruitment/RecruitmentMap.jsx
@@ -157,7 +157,6 @@ function RecruitmentMapPage() {
             jobs={filteredJobs}
             selectedJob={selectedJob}
             onSelectJob={handleSelectJob}
-            mapCenter={mapCenter}
             onBoundsChange={handleBoundsChange}
           />
         </div>

--- a/src/pages/recruitment/RecruitmentMap.jsx
+++ b/src/pages/recruitment/RecruitmentMap.jsx
@@ -6,6 +6,7 @@ import MapContainer from "../../components/recruitment/recruitment_map/MapContai
 import RecruitmentFilter from "../../components/recruitment/recruitment_map/RecruitmentFilter";
 import RecruitmentSearch from "../../components/recruitment/recruitment_map/RecruitmentSearch";
 import styles from "./RecruitmentMap.module.scss";
+import MapBoundsDisplay from "../../components/recruitment/recruitment_map/MapBoundsDisplay";
 import { jobs } from "../../data/jobs";
 
 function RecruitmentMapPage() {
@@ -17,7 +18,8 @@ function RecruitmentMapPage() {
   const [selectedSkills, setSelectedSkills] = useState([]);
   const [education, setEducation] = useState(0);
   const [mapCenter, setMapCenter] = useState({ lat: 37.5665, lng: 126.978 }); // 기본 중심: 서울시청
-
+  const [mapBounds, setMapBounds] = useState(null);
+  const [isMapSearchActive, setIsMapSearchActive] = useState(false);
 
   const handleSelectJob = (job) => {
     setSelectedJob(job);
@@ -26,11 +28,13 @@ function RecruitmentMapPage() {
   const handleFilterChange = (type) => {
     setFilterType(type);
     setSelectedJob(null);
+    setIsMapSearchActive(false);
   };
 
   const handleRegionFilterChange = (region) => {
     setRegionFilter(region);
     setSelectedJob(null);
+    setIsMapSearchActive(false);
   };
 
   const handleSalaryChange = (value) => setSalary(parseInt(value, 10));
@@ -42,11 +46,20 @@ function RecruitmentMapPage() {
   };
   const handleEducationChange = (value) => setEducation(parseInt(value, 10));
 
+  const handleBoundsChange = (bounds) => {
+    setMapBounds(bounds);
+  };
+
+  const handleSearchCurrentMap = () => {
+    setIsMapSearchActive(true);
+  };
+
   const handleSearch = (keyword) => {
     if (!keyword.trim()) {
       alert("검색어를 입력해주세요.");
       return;
     }
+    setIsMapSearchActive(false);
     const ps = new window.kakao.maps.services.Places();
     ps.keywordSearch(keyword, (data, status) => {
       if (status === window.kakao.maps.services.Status.OK) {
@@ -64,6 +77,13 @@ function RecruitmentMapPage() {
     const typeMatch = filterType === "all" || job.type === filterType;
     const regionMatch = regionFilter === "all" || job.region === regionFilter;
 
+    const boundsMatch = !isMapSearchActive || !mapBounds || (
+      job.lat >= mapBounds.southWest.lat &&
+      job.lat <= mapBounds.northEast.lat &&
+      job.lng >= mapBounds.southWest.lng &&
+      job.lng <= mapBounds.northEast.lng
+    );
+
     const salaryMatch = () => {
       if (salary === 0) return true; // '전체' 또는 '회사 내규'는 모든 연봉을 포함
       if (salary === 3000) return job.salary >= 3000 && job.salary < 4000;
@@ -76,19 +96,19 @@ function RecruitmentMapPage() {
       // 사용자가 '경력무관' 선택 시 모든 공고 포함
       if (experience === 0) return true;
       // 공고가 '경력무관'일 경우 항상 포함
-      if (job.experience === 'all') return true;
+      if (job.experience === "all") return true;
 
       // '신입' 처리
-      const jobIsNew = job.experience === 'new';
+      const jobIsNew = job.experience === "new";
       const filterIsNew = experience === 1;
       if (filterIsNew) return jobIsNew;
 
       // 연차 비교
       const jobExpYear = parseInt(job.experience, 10);
       if (isNaN(jobExpYear)) return jobIsNew; // job.experience가 'new' 같은 문자열일 경우
-      
+
       // 사용자가 설정한 경력(N년 이하)보다 요구 경력이 낮거나 같으면 통과
-      return jobExpYear <= (experience - 1);
+      return jobExpYear <= experience - 1;
     };
 
     const skillsMatch =
@@ -97,14 +117,7 @@ function RecruitmentMapPage() {
 
     const educationMatch = education === 0 || job.education <= education;
 
-    return (
-      typeMatch &&
-      regionMatch &&
-      salaryMatch() &&
-      experienceMatch() &&
-      skillsMatch &&
-      educationMatch
-    );
+    return typeMatch && regionMatch && salaryMatch() && experienceMatch && skillsMatch && educationMatch && boundsMatch;
   });
 
   return (
@@ -138,11 +151,14 @@ function RecruitmentMapPage() {
           </div>
         </div>
         <div className={styles.mapWrapper}>
+          <MapBoundsDisplay bounds={mapBounds} />
           <MapContainer
+          onSearchCurrentMap={handleSearchCurrentMap}
             jobs={filteredJobs}
             selectedJob={selectedJob}
             onSelectJob={handleSelectJob}
             mapCenter={mapCenter}
+            onBoundsChange={handleBoundsChange}
           />
         </div>
       </main>

--- a/src/pages/recruitment/RecruitmentMap.module.scss
+++ b/src/pages/recruitment/RecruitmentMap.module.scss
@@ -40,6 +40,7 @@
 }
 
 .mapWrapper {
+  position: relative;
   flex-grow: 1; // 너비 비율
   display: flex;
   border-radius: 12px;


### PR DESCRIPTION
# feat: 지도 중심 회사 검색을 위한 위도/경도 기능 추가

## 🚀 주요 변경 사항

- **주요 기능**
  - `RecruitmentMap` 페이지에서 지도를 움직일 때마다 중심의 위도와 경도를 상태로 관리합니다.
  - "여기서 검색" 버튼을 추가하여, 현재 지도 중심의 위도/경도를 기반으로 채용 정보를 다시 불러옵니다.
  - `MapContainer` 컴포넌트에서 `kakao.maps.event.addListener`를 사용하여 지도의 `center_changed` 이벤트를 감지하고, 변경된 중심 좌표를 부모 컴포넌트로 전달

## 🚨 리뷰어에게

- 지도 이동 시 API 요청이 너무 자주 발생하지 않도록, 사용자가 "여기서 검색" 버튼을 눌렀을 때만 데이터를 가져오도록 구현했습니다. 
- 위도, 경도 상태가 잘 전달되고, API 요청이 올바르게 나가는지 확인 부탁드립니다.

## 📸 스크린샷 (선택 사항)

(지도 화면 및 기능 시연 스크린샷을 여기에 첨부해주세요.)
<img width="1009" height="690" alt="image" src="https://github.com/user-attachments/assets/516ebf41-0165-473e-8569-20514d5338da" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 지도에서 현재 보이는 영역(경계)에 따라 채용 공고를 필터링할 수 있는 기능이 추가되었습니다.
  * 지도 경계 정보를 시각적으로 확인할 수 있는 표시창이 지도 상단에 추가되었습니다.
  * "현재 지도에서 검색" 버튼이 지도 하단에 노출되어, 지도 위치에 맞는 채용 공고 검색이 가능합니다.
  * 공통 버튼 컴포넌트가 추가되어 다양한 스타일의 버튼 사용이 가능해졌습니다.

* **스타일**
  * 지도 및 버튼 관련 UI 요소의 스타일이 개선되어 가독성과 사용성이 향상되었습니다.
  * 지도 컨테이너 및 버튼의 위치 지정 스타일이 추가되어 UI 요소 배치가 명확해졌습니다.
  * 지도 래퍼에 위치 지정 속성이 추가되어 내부 요소의 절대 위치 지정이 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->