### PR TITLE
사이드바에 채용 공고 지도 메뉴 아이템 추가

### DIFF
--- a/src/components/common/Sidebar/Sidebar.jsx
+++ b/src/components/common/Sidebar/Sidebar.jsx
@@ -16,6 +16,8 @@ import {
   FaRankingStar,
   FaAnglesLeft,
   FaMapLocationDot,
+  FaMap,
+  FaCalendarCheck
 } from "react-icons/fa6";
 import logo from "../../../assets/images/logo.png";
 import { useNavigate } from "react-router-dom";
@@ -34,6 +36,7 @@ function getQuickMenuItems() {
     // { icon: <FaBolt />, label: "빠른 검색" },
     { icon: <FaBell />, label: "알림" },
     { icon: <FaMapLocationDot />, label: "스터디룸 예약", link: "/studyroom" }, // 새로 추가
+    { icon: <FaMap />, label: "채용 공고 지도", link: "/recruitment/map" },
   ];
 }
 


### PR DESCRIPTION
close#28 

## 🚀 주요 변경 사항

- 사이드바에 채용 공고 지도 메뉴 아이템 추가

## 🚨 리뷰어에게

## 📸 스크린샷 (선택 사항)
<img width="462" height="457" alt="image" src="https://github.com/user-attachments/assets/a71a6478-198b-48f7-8290-620240cbeb42" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사이드바 퀵 메뉴에 "채용 공고 지도" 항목이 추가되어, `/recruitment/map`로 바로 이동할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->