### PR TITLE
[기능] 채용 정보 페이지에 jobId 파라미터 지원 추가

### DIFF
--- a/src/components/Dashboard/LatestRecruitmentCarousel.jsx
+++ b/src/components/Dashboard/LatestRecruitmentCarousel.jsx
@@ -140,17 +140,14 @@ function LatestRecruitmentCarousel() {
     window.open("/recruitment/map", "_blank");
   };
 
-  const handleCardClick = (recruitment, e) => {
+  const handleCardClick = (recruitmentId, e) => {
     // 드래그가 발생했으면 클릭 이벤트 차단
     if (isDragging) {
       e.preventDefault();
       e.stopPropagation();
       return;
     }
-    window.open(
-      `/recruitment/map/${recruitment.id}?lat=${recruitment.latitude}&lng=${recruitment.longitude}`,
-      "_blank"
-    );
+    window.open(`/recruitment/map/${recruitmentId}`, "_blank");
   };
 
   return (
@@ -204,7 +201,7 @@ function LatestRecruitmentCarousel() {
               <div
                 key={recruitment.id}
                 className={styles.recruitmentCard}
-                onClick={(e) => handleCardClick(recruitment, e)}
+                onClick={(e) => handleCardClick(recruitment.id, e)}
               >
                 <div className={styles.cardHeader}>
                   <div className={styles.companyInfo}>

--- a/src/components/Dashboard/LatestRecruitmentCarousel.jsx
+++ b/src/components/Dashboard/LatestRecruitmentCarousel.jsx
@@ -140,14 +140,17 @@ function LatestRecruitmentCarousel() {
     window.open("/recruitment/map", "_blank");
   };
 
-  const handleCardClick = (recruitmentId, e) => {
+  const handleCardClick = (recruitment, e) => {
     // 드래그가 발생했으면 클릭 이벤트 차단
     if (isDragging) {
       e.preventDefault();
       e.stopPropagation();
       return;
     }
-    window.open(`/recruitment/map/${recruitmentId}`, "_blank");
+    window.open(
+      `/recruitment/map/${recruitment.id}?lat=${recruitment.latitude}&lng=${recruitment.longitude}`,
+      "_blank"
+    );
   };
 
   return (
@@ -201,7 +204,7 @@ function LatestRecruitmentCarousel() {
               <div
                 key={recruitment.id}
                 className={styles.recruitmentCard}
-                onClick={(e) => handleCardClick(recruitment.id, e)}
+                onClick={(e) => handleCardClick(recruitment, e)}
               >
                 <div className={styles.cardHeader}>
                   <div className={styles.companyInfo}>

--- a/src/pages/recruitment/RecruitmentMap.jsx
+++ b/src/pages/recruitment/RecruitmentMap.jsx
@@ -1,5 +1,10 @@
 import React, { useState, useEffect, createContext } from "react";
-import { validateAndBuildParams, getRecruitments, getRecruitmentFilters } from "../../api/recruitmentService";
+import { useParams } from "react-router-dom";
+import {
+  validateAndBuildParams,
+  getRecruitments,
+  getRecruitmentFilters,
+} from "../../api/recruitmentService";
 import RecruitmentMapHeader from "../../components/recruitment/recruitment_map/RecruitmentPageHeader";
 import RecruitmentList from "../../components/recruitment/recruitment_map/RecruitmentList";
 import RecruitmentDetail from "../../components/recruitment/recruitment_map/RecruitmentDetail";
@@ -14,8 +19,9 @@ import MapBoundsDisplay from "../../components/recruitment/recruitment_map/MapBo
 export const FilterDataContext = createContext(null);
 
 function RecruitmentMapPage() {
+  const { jobId } = useParams(); // URL 파라미터에서 jobId 추출
   // 기존 상태
-  const [selectedJob, setSelectedJob] = useState(null);
+  const [selectedJob, setSelectedJob] = useState(jobId ? { id: jobId } : null); // jobId가 있으면 해당 채용 공고 선택
   const [filterType, setFilterType] = useState("all");
   const [regionFilter, setRegionFilter] = useState("all");
   const [salary, setSalary] = useState(0);
@@ -31,19 +37,19 @@ function RecruitmentMapPage() {
   const [recruitments, setRecruitments] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  
+
   // 필터 데이터 상태
   const [filterData, setFilterData] = useState({
     techStacks: [],
     educationOptions: [],
-    experienceOptions: []
+    experienceOptions: [],
   });
   const [filterDataLoading, setFilterDataLoading] = useState(true);
-  
+
   // 기술 스택 ID로 기술 스택 정보 찾기 함수
   const findTechStackById = (id) => {
     if (filterDataLoading || !filterData.techStacks) return null;
-    return filterData.techStacks.find(stack => stack.id === id) || null;
+    return filterData.techStacks.find((stack) => stack.id === id) || null;
   };
 
   const handleSelectJob = (job) => {
@@ -123,7 +129,9 @@ function RecruitmentMapPage() {
         setShouldUseMapBounds(false);
       } catch (err) {
         console.error("채용 정보 조회 실패:", err);
-        setError(err.response?.data?.message || "채용 정보를 불러오는데 실패했습니다.");
+        setError(
+          err.response?.data?.message || "채용 정보를 불러오는데 실패했습니다."
+        );
         setRecruitments([]);
       } finally {
         setLoading(false);
@@ -172,7 +180,9 @@ function RecruitmentMapPage() {
   };
 
   return (
-    <FilterDataContext.Provider value={{ filterData, loading: filterDataLoading, findTechStackById }}>
+    <FilterDataContext.Provider
+      value={{ filterData, loading: filterDataLoading, findTechStackById }}
+    >
       <div className={styles.pageContainer}>
         <RecruitmentMapHeader />
         <main className={styles.mainContent}>
@@ -198,41 +208,41 @@ function RecruitmentMapPage() {
                 />
               )}
             </div>
-          <div className={styles.listContainer}>
-            {loading && <div>로딩 중...</div>}
-            {error && <div>에러가 발생했습니다.</div>}
-            {!loading && !error && (
-              <div className={styles.recruitmentContent}>
-                <RecruitmentList
-                  jobs={recruitments} // API 데이터로 변경
-                  selectedJob={selectedJob}
-                  onSelectJob={handleSelectJob}
-                />
-              </div>
-            )}
+            <div className={styles.listContainer}>
+              {loading && <div>로딩 중...</div>}
+              {error && <div>에러가 발생했습니다.</div>}
+              {!loading && !error && (
+                <div className={styles.recruitmentContent}>
+                  <RecruitmentList
+                    jobs={recruitments} // API 데이터로 변경
+                    selectedJob={selectedJob}
+                    onSelectJob={handleSelectJob}
+                  />
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-        {selectedJob && (
-        <div className={styles.detailContainer}>
-       
-          <RecruitmentDetail
-            job={selectedJob}
-            onClose={() => setSelectedJob(null)}
-          />
-        </div>)}
-        
-        <div className={styles.mapWrapper}>
-          <MapBoundsDisplay bounds={mapBounds} />
-          <MapContainer
-            onSearchCurrentMap={handleSearchCurrentMap}
-            jobs={recruitments} // API 데이터로 변경
-            selectedJob={selectedJob}
-            onSelectJob={handleSelectJob}
-            onBoundsChange={handleBoundsChange}
-          />
-        </div>
-      </main>
-    </div>
+          {selectedJob && (
+            <div className={styles.detailContainer}>
+              <RecruitmentDetail
+                job={selectedJob}
+                onClose={() => setSelectedJob(null)}
+              />
+            </div>
+          )}
+
+          <div className={styles.mapWrapper}>
+            <MapBoundsDisplay bounds={mapBounds} />
+            <MapContainer
+              onSearchCurrentMap={handleSearchCurrentMap}
+              jobs={recruitments} // API 데이터로 변경
+              selectedJob={selectedJob}
+              onSelectJob={handleSelectJob}
+              onBoundsChange={handleBoundsChange}
+            />
+          </div>
+        </main>
+      </div>
     </FilterDataContext.Provider>
   );
 }

--- a/src/pages/recruitment/RecruitmentMap.jsx
+++ b/src/pages/recruitment/RecruitmentMap.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, createContext } from "react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import {
   validateAndBuildParams,
   getRecruitments,
@@ -20,12 +20,8 @@ export const FilterDataContext = createContext(null);
 
 function RecruitmentMapPage() {
   const { jobId } = useParams(); // URL 파라미터에서 jobId 추출
-  const [searchParams] = useSearchParams();
-  const paramLatitude = searchParams.get("lat");
-  const paramLongitude = searchParams.get("lng");
-
   // 기존 상태
-  const [selectedJob, setSelectedJob] = useState(null);
+  const [selectedJob, setSelectedJob] = useState(jobId ? { id: jobId } : null); // jobId가 있으면 해당 채용 공고 선택
   const [filterType, setFilterType] = useState("all");
   const [regionFilter, setRegionFilter] = useState("all");
   const [salary, setSalary] = useState(0);
@@ -49,16 +45,6 @@ function RecruitmentMapPage() {
     experienceOptions: [],
   });
   const [filterDataLoading, setFilterDataLoading] = useState(true);
-
-  useEffect(() => {
-    if (jobId) {
-      setSelectedJob({ id: jobId });
-      setMapCenter({
-        lat: parseFloat(paramLatitude) || 37.5665, // 기본값 서울시청
-        lng: parseFloat(paramLongitude) || 126.978, // 기본값 서울시청
-      });
-    }
-  }, [jobId, paramLatitude, paramLongitude]);
 
   // 기술 스택 ID로 기술 스택 정보 찾기 함수
   const findTechStackById = (id) => {

--- a/src/pages/recruitment/RecruitmentMap.jsx
+++ b/src/pages/recruitment/RecruitmentMap.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, createContext } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import {
   validateAndBuildParams,
   getRecruitments,
@@ -20,8 +20,12 @@ export const FilterDataContext = createContext(null);
 
 function RecruitmentMapPage() {
   const { jobId } = useParams(); // URL 파라미터에서 jobId 추출
+  const [searchParams] = useSearchParams();
+  const paramLatitude = searchParams.get("lat");
+  const paramLongitude = searchParams.get("lng");
+
   // 기존 상태
-  const [selectedJob, setSelectedJob] = useState(jobId ? { id: jobId } : null); // jobId가 있으면 해당 채용 공고 선택
+  const [selectedJob, setSelectedJob] = useState(null);
   const [filterType, setFilterType] = useState("all");
   const [regionFilter, setRegionFilter] = useState("all");
   const [salary, setSalary] = useState(0);
@@ -45,6 +49,16 @@ function RecruitmentMapPage() {
     experienceOptions: [],
   });
   const [filterDataLoading, setFilterDataLoading] = useState(true);
+
+  useEffect(() => {
+    if (jobId) {
+      setSelectedJob({ id: jobId });
+      setMapCenter({
+        lat: parseFloat(paramLatitude) || 37.5665, // 기본값 서울시청
+        lng: parseFloat(paramLongitude) || 126.978, // 기본값 서울시청
+      });
+    }
+  }, [jobId, paramLatitude, paramLongitude]);
 
   // 기술 스택 ID로 기술 스택 정보 찾기 함수
   const findTechStackById = (id) => {

--- a/src/routes/public.routes.jsx
+++ b/src/routes/public.routes.jsx
@@ -8,6 +8,7 @@ export default [
     children: [
       { path: "/", element: <HomePage /> },
       { path: "/recruitment/map", element: <RecruitmentMapPage /> },
+      { path: "/recruitment/map/:jobId", element: <RecruitmentMapPage /> },
     ],
   },
 ];


### PR DESCRIPTION
# feat: 채용 정보 페이지에 jobId 파라미터 지원 추가

## 🚀 주요 변경 사항
* URL 파라미터를 통한 특정 채용 공고 직접 접근 기능 추가
- **주요 기능**

## 🚨 리뷰어에게
일단은 selectedJob에 바로 jobId를 때려 박았습니다.
setMapCenter를 하게 했었는데 이것보단 나중에 mapCenter가 적용 된 다음에 detail에서 콜백으로 center를 가지고 오거나 기본 정보를 fetch해온걸 넣는게 나을 것 같아서 revert했습니다.

## 📸 스크린샷 (선택 사항)

closes #32 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * URL에 포함된 채용 공고 ID로 채용 지도를 미리 특정 공고가 선택된 상태로 열 수 있습니다.

* **사용성 개선**
  * 채용 지도 페이지의 레이아웃과 상세 패널 표시 방식이 개선되어 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->